### PR TITLE
Proposed changes to unit tests

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -1,5 +1,12 @@
 LICENSE
 MANIFEST
+MANIFEST.SKIP
 Makefile.PL
 README.md
 lib/Illumos/SMF.pm
+setup/build-devel.sh
+setup/sdbs.inc
+t/smf.t
+t/manifest.t
+t/pod.t
+.travis.yml

--- a/MANIFEST.SKIP
+++ b/MANIFEST.SKIP
@@ -1,0 +1,12 @@
+^MYMETA.json$
+^MYMETA.yml$
+^_eumm
+^Makefile$
+^blib/
+^pm_to_blib
+^blibdirs
+^Build$
+^Build.bat$
+^pod2htm
+^_build/
+^.git

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -10,6 +10,14 @@ WriteMakefile(
     ABSTRACT     => 'A Perl Module to administrate Illumos SMF.',
     AUTHOR       => 'Dominik Hassler <hadfl@cpan.org>',
     LICENSE      => 'gpl_3',
+    CONFIGURE_REQUIRES => {
+        'ExtUtils::MakeMaker' => 0,
+    },
+    BUILD_REQUIRES   => {
+        'Test::More' => 0,
+    },
+    dist  => { COMPRESS => 'gzip -9f', SUFFIX => 'gz', },
+    clean => { FILES => 'Illumos-SMF-*' },
     META_MERGE   => {
         requires  => {perl => '5.010001'},
         resources => {

--- a/lib/Illumos/SMF.pm
+++ b/lib/Illumos/SMF.pm
@@ -19,7 +19,13 @@ sub new {
 
     # add Illumos::Zone instance if zone support is required
     $self->{zonesupport} && do {
-        require Illumos::Zones;
+        eval {
+            require Illumos::Zones;
+        };
+        if ($@) {
+            die "ERROR: Unable to load package Illumos::Zones.";
+        }
+
         $self->{zone} = Illumos::Zones->new(debug => $self->{debug});
     };
     

--- a/t/manifest.t
+++ b/t/manifest.t
@@ -1,0 +1,11 @@
+#!perl -T
+use 5.006;
+use strict;
+use warnings FATAL => 'all';
+use Test::More;
+
+my $min_tcm = 0.9;
+eval "use Test::CheckManifest $min_tcm";
+plan skip_all => "Test::CheckManifest $min_tcm required" if $@;
+
+ok_manifest();

--- a/t/pod.t
+++ b/t/pod.t
@@ -1,0 +1,12 @@
+#!perl -T
+use 5.006;
+use strict;
+use warnings FATAL => 'all';
+use Test::More;
+
+# Ensure a recent version of Test::Pod
+my $min_tp = 1.22;
+eval "use Test::Pod $min_tp";
+plan skip_all => "Test::Pod $min_tp required for testing POD" if $@;
+
+all_pod_files_ok();

--- a/t/smf.t
+++ b/t/smf.t
@@ -4,7 +4,9 @@ use FindBin;
 use lib $FindBin::Bin.'/../thirdparty/lib/perl5';
 use lib $FindBin::Bin.'/../lib';
 
-use Test::More tests => 3;
+use Test::More;
+plan skip_all => 'Minimum perl v5.14 required.' if ($] < 5.014000);
+plan tests => 3;
 
 use_ok 'Illumos::SMF';
 


### PR DESCRIPTION
HI,

Please review the following changes.

```
- In the constructor new(), handle error "Can't locate Illumos/Zones.pm".
- Updated test script "t/smf.t" to check if the perl version is 5.14 or above before running the test
  as it uses perl syntax compatible with 5.14 or above.
- Updated "Makefile.PL" script and added keys like 'CONFIGURE_REQUIRE, BUILD_REQUIRES, dist and clean.
- Added "MANIFEST.SKIP" file.
- Added standard unit test scripts i.e. "t/manifest.t" and "t/pod.t".
- Updated "MANIFEST" file to include the following files:
  - MANIFEST.SKIP
  - setup/build-devel.sh
  - setup/sdbs.inc
  - t/smf.t
  - t/manifest.t
  - t/pod.t
  - .travis.yml
```

I would also suggest to either impose minimum perl v5.14 or stop using v5.14 or above compatible syntax in the source code.

Many Thanks.

Best Regards,
Mohammad S Anwar
